### PR TITLE
send and receive a DNSlookup message

### DIFF
--- a/client/Program.cs
+++ b/client/Program.cs
@@ -1,5 +1,6 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.ComponentModel;
+using System.Data.SqlTypes;
 using System.Net;
 using System.Net.Sockets;
 using System.Security.Cryptography;
@@ -35,6 +36,7 @@ class ClientUDP
     static string configContent = File.ReadAllText(configFile);
     static Setting? setting = JsonSerializer.Deserialize<Setting>(configContent);
 
+
     private static Socket socket = new(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
 
     private static IPEndPoint ServerEndpoint = new IPEndPoint(IPAddress.Loopback, 49153);
@@ -46,56 +48,51 @@ class ClientUDP
         //TODO: [Create endpoints and socket]
         SocketCreation(socket, ClientEndpoint);
         EndPoint convertedEndpoint = (EndPoint)ServerEndpoint;
-        //TODO: [Create and send HELLO]
+       
         try
         {
+            //TODO: [Create and send HELLO]
 
-            //verstuurd hello
             byte[] hellomaxsize = Encoding.ASCII.GetBytes("HELLO");
-            int bytessent = socket.SendTo(hellomaxsize,ServerEndpoint);
-            Console.WriteLine($"Sent {bytessent} bytes to {ServerEndpoint }");
+            int hellobytes = socket.SendTo(hellomaxsize,ServerEndpoint);
+            Console.WriteLine($"Sent {hellobytes} bytes to {ServerEndpoint }");
 
-            //ontvangt welcome
+            //
+
+            //TODO: [Receive and print Welcome from server]
+
             byte[] welcomemaxsize = Encoding.ASCII.GetBytes("WELCOME");
             int recbytes = socket.ReceiveFrom(welcomemaxsize,ref convertedEndpoint);
-          
             string convertedmessage =  Encoding.ASCII.GetString(welcomemaxsize,0,recbytes);
             Console.WriteLine("received message: " + convertedmessage);
-       
+
+            //
+
+            // TODO: [Create and send DNSLookup Message]
+
+            Message Message1 = new Message ();
+            Message1.MsgId = 1;
+            Message1.MsgType = MessageType.DNSLookup;
+            Message1.Content = "www.outlook.com";
             
-        }
-        catch (Exception ex)
-        {
-             Console.WriteLine("exception message:" + ex.Message);
-        }
-          
+            string  serializeDNS = JsonSerializer.Serialize(Message1);
+            byte[] DNSMessageSize = Encoding.ASCII.GetBytes(serializeDNS);
+            int DNSBytesSent = socket.SendTo(DNSMessageSize, ServerEndpoint);
+            Console.WriteLine($"Sent {DNSBytesSent} to {ServerEndpoint }");
 
-
-        //TODO: [Receive and print Welcome from server]
-       
-        try 
-        {
-            byte[] messagemaxsize = new byte[10];
-         
-            int recbytes = socket.ReceiveFrom(messagemaxsize,ref convertedEndpoint);
-            string encoded = Encoding.ASCII.GetString(messagemaxsize,0,recbytes);
-            Console.WriteLine("encoded: " +encoded);
-
+            //
         }
         catch (Exception ex)
         {
             Console.WriteLine("exception message:" + ex.Message);
         }
-
-        socket.Close();
-        // TODO: [Create and send DNSLookup Message]
-
+       
         //TODO: [Receive and print DNSLookupReply from server]
-
 
         //TODO: [Send Acknowledgment to Server]
 
         // TODO: [Send next DNSLookup to server]
+
         // repeat the process until all DNSLoopkups (correct and incorrect onces) are sent to server and the replies with DNSLookupReply
 
         //TODO: [Receive and print End from server]

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Data.SqlTypes;
 using System.Net;
@@ -57,45 +57,46 @@ class ServerUDP
         // TODO: [Create a socket and endpoints and bind it to the server IP address and port number]
        
         ServerBinding(socket, ServerEndpoint); 
+
+        // Converts IPEndpoint to Endpoint so that we can use it to receive messages
         EndPoint convertedEndpoint = (EndPoint)ClientEndpoint;
         // TODO:[Receive and print a received Message from the client]
       
-        // TODO:[Receive and print Hello]
-            try   
-            {
-                byte[] messagesize = new byte[5];
-                
-                Console.WriteLine("trying to receive message");
-                int receivedbytes = socket.ReceiveFrom(messagesize,ref convertedEndpoint);
-                string convertedmessage =  Encoding.ASCII.GetString(messagesize,0,receivedbytes);
-                
-                
-                Console.WriteLine($" {convertedmessage}");
+        try   
+        { 
+            // TODO:[Receive and print Hello]
+            byte[] messagesize = new byte[5];
+            Console.WriteLine("trying to receive message");
+            int receivedbytes = socket.ReceiveFrom(messagesize,ref convertedEndpoint);
+            string convertedmessage =  Encoding.ASCII.GetString(messagesize,0,receivedbytes);
+            Console.WriteLine(convertedmessage);
 
-                byte[] message = Encoding.ASCII.GetBytes("WELCOME");
-                Console.WriteLine("Sending data.");
-                int bytessent = socket.SendTo(message,convertedEndpoint);    
-                Console.WriteLine($"Sent welcome message to: " + convertedEndpoint);
+            // TODO:[Send Welcome to the client]
+            byte[] welcomeMessageSize = Encoding.ASCII.GetBytes("WELCOME");
+            Console.WriteLine("Sending data.");
+            int bytessent = socket.SendTo(welcomeMessageSize,convertedEndpoint);    
+            Console.WriteLine($"Sent welcome message to: " + convertedEndpoint);
 
+            // TODO:[Receive and print DNSLookup]
+            byte[] DNSMessageSize = new byte[1000];
+            int receivedDNS = socket.ReceiveFrom(DNSMessageSize, ref convertedEndpoint);
+            string convertedDNSmessage = Encoding.ASCII.GetString(DNSMessageSize,0,receivedDNS);
+            Console.WriteLine(convertedDNSmessage);
 
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine("exception: " + ex.Message);
-            }
-           
+            //door de json file heen zoeken dmv de deserializedDNS
+            Message deserializedDNS = JsonSerializer.Deserialize<Message>(convertedDNSmessage);
 
-
-        // TODO:[Send Welcome to the client]
-          
-        // TODO:[Receive and print DNSLookup]
-
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("exception: " + ex.Message);
+        }
+        
 
         // TODO:[Query the DNSRecord in Json file]
+        
 
         // TODO:[If found Send DNSLookupReply containing the DNSRecord]
-
-
 
         // TODO:[If not found Send Error]
 
@@ -109,9 +110,9 @@ class ServerUDP
 
     public static void ServerBinding(Socket socket, IPEndPoint endpoint)
     {
-
         socket.Bind(endpoint);
         Console.WriteLine("connection binded");
-        
+
+
     }
 }


### PR DESCRIPTION
client sends a DNSLookup message by serializing Message object to server and server receives the DNSLookup message and deserializes it so that it can be compared later on to search for it in the DNSrecords JSON file